### PR TITLE
Fixes json_test.go

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -60,7 +60,8 @@ func TestSimple(t *testing.T) {
 		obj = obj,
 	}
 	obj.obj2 = obj2
-	assert(json.encode(obj) == nil)
+	local status, err = pcall(function() json.encode(obj) end)
+	assert(err == "cannot encode recursively nested tables to JSON", err)
 	`
 	s := lua.NewState()
 	Preload(s)


### PR DESCRIPTION
The test to verify JSON encoding of a recursive object currently fails.  This modifies the Lua block to check the error message, similar to other json#encode failure assertions.

In the longer term this repository should be rebased off of github.com/layeh/gopher-json which seems to pass even with the previous assertion structure of `assert(json.encode(obj) == nil)`.